### PR TITLE
Support timezone configuration and daily guide updates

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ PORT="3000"
 API_URL="http://localhost:3000" # Replace with your local IP or domain if you want to access it across the network
 PROXY_CONTENT="TRUE" # Set to FALSE if you don't want to proxy content
 SOCKS5="" # Add SOCKS5 proxy details for DLHD request if needed "user:password@proxy.example.com:1080"
+TZ="UTC" # Set the timezone used for schedules and guide.xml (e.g. "America/New_York")
+GUIDE_UPDATE="03:00" # Daily time (HH:MM) to refresh guide.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets/external/
 __pycache__/
 /.idea/
 .env
+guide.xml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A self-hosted IPTV proxy built with [Reflex](https://reflex.dev), enabling you t
 - **🔎 Event Search**: Quickly find the right channel for live events or sports.
 - **📄 Playlist Integration**: Download the `playlist.m3u8` and use it with Jellyfin or any IPTV client.
 - **🗓️ XMLTV Guide**: Access scheduling information at `guide.xml` for use with media servers like Jellyfin.
+- **🕒 Daily Guide Updates**: Automatically refresh `guide.xml` once per day at a user-defined time.
 - **⚙️ Customizable Hosting**: Host the application locally or deploy it via Docker with various configuration options.
 
 ---
@@ -69,6 +70,8 @@ docker run -p 3000:3000 dlhd-proxy
 - **API_URL**: Set the domain or IP where the server is reachable.
 - **SOCKS5**: Proxy DLHD traffic through a SOCKS5 server if needed.
 - **PROXY_CONTENT**: Proxy video content itself through your server (optional).
+- **TZ**: Timezone used for schedules and guide generation (e.g., `America/New_York`).
+- **GUIDE_UPDATE**: Daily time (`HH:MM`) to refresh `guide.xml`.
 
 Edit the `.env` for docker compose.
 

--- a/dlhd_proxy/dlhd_proxy.py
+++ b/dlhd_proxy/dlhd_proxy.py
@@ -74,3 +74,4 @@ app = rx.App(
 )
 
 app.register_lifespan_task(backend.update_channels)
+app.register_lifespan_task(backend.auto_update_guide)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - API_URL=${API_URL}
       - PROXY_CONTENT=${PROXY_CONTENT}
       - SOCKS5=${SOCKS5}
+      - TZ=${TZ}
+      - GUIDE_UPDATE=${GUIDE_UPDATE}
     ports:
       - "${PORT}:${PORT}"
     restart: unless-stopped

--- a/rxconfig.py
+++ b/rxconfig.py
@@ -4,8 +4,12 @@ import os
 
 proxy_content = os.environ.get("PROXY_CONTENT", "TRUE").upper() == "TRUE"
 socks5 = os.environ.get("SOCKS5", "")
+timezone = os.environ.get("TZ", "UTC")
+guide_update = os.environ.get("GUIDE_UPDATE", "03:00")
 
-print(f"PROXY_CONTENT: {proxy_content}\nSOCKS5: {socks5}")
+print(
+    f"PROXY_CONTENT: {proxy_content}\nSOCKS5: {socks5}\nTZ: {timezone}\nGUIDE_UPDATE: {guide_update}"
+)
 
 config = rx.Config(
     app_name="dlhd_proxy",
@@ -17,3 +21,6 @@ config = rx.Config(
         rx.plugins.TailwindV4Plugin(),
     ],
 )
+
+config.timezone = timezone
+config.guide_update = guide_update


### PR DESCRIPTION
## Summary
- allow setting timezone with `TZ` env var and schedule guide refresh time via `GUIDE_UPDATE`
- use configured timezone for schedule page and guide.xml generation
- add background task that regenerates guide.xml once per day

## Testing
- `python -m py_compile rxconfig.py dlhd_proxy/pages/schedule.py dlhd_proxy/backend.py dlhd_proxy/dlhd_proxy.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3c646f2d8832fbfd5713944b28044