### PR TITLE
Add configurable channel filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 /.idea/
 .env
 guide.xml
+channels.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A self-hosted IPTV proxy built with [Reflex](https://reflex.dev), enabling you t
 - **🔎 Event Search**: Quickly find the right channel for live events or sports.
 - **📄 Playlist Integration**: Download the `playlist.m3u8` and use it with Jellyfin or any IPTV client.
 - **🗓️ XMLTV Guide**: Access scheduling information at `guide.xml` for use with media servers like Jellyfin.
+- **✅ Channel Filtering**: Select which channels appear in the playlist and generated guide.
 - **🕒 Daily Guide Updates**: Automatically refresh `guide.xml` once per day at a user-defined time.
 - **⚙️ Customizable Hosting**: Host the application locally or deploy it via Docker with various configuration options.
 

--- a/dlhd_proxy/components/navbar.py
+++ b/dlhd_proxy/components/navbar.py
@@ -57,6 +57,7 @@ def navbar(search=None) -> rx.Component:
                     ),
                     rx.hstack(
                         navbar_icons_item("Schedule", "calendar-sync", "/schedule"),
+                        navbar_icons_item("Channels", "list-checks", "/channels"),
                         navbar_icons_item("playlist.m3u8", "file-down", "/playlist"),
                         navbar_icons_item("guide.xml", "file-text", "/guide.xml"),
                         navbar_icons_item("Github", "github", "https://github.com/gookie-dev/dlhd-proxy", True),
@@ -95,6 +96,7 @@ def navbar(search=None) -> rx.Component:
                             ),
                             rx.menu.content(
                                 navbar_icons_menu_item("Schedule", "calendar-sync", "/schedule"),
+                                navbar_icons_menu_item("Channels", "list-checks", "/channels"),
                                 navbar_icons_menu_item("playlist.m3u8", "file-down", "/playlist"),
                                 navbar_icons_menu_item("guide.xml", "file-text", "/guide.xml"),
                                 navbar_icons_menu_item("Github", "github", "https://github.com/gookie-dev/dlhd-proxy", True),

--- a/dlhd_proxy/dlhd_proxy.py
+++ b/dlhd_proxy/dlhd_proxy.py
@@ -17,7 +17,7 @@ class State(rx.State):
         return [ch for ch in self.channels if self.search_query.lower() in ch.name.lower()]
 
     async def on_load(self):
-        self.channels = backend.get_channels()
+        self.channels = backend.get_enabled_channels()
 
 
 @rx.page("/", on_load=State.on_load)

--- a/dlhd_proxy/pages/__init__.py
+++ b/dlhd_proxy/pages/__init__.py
@@ -1,6 +1,7 @@
 from .watch import watch
 from .playlist import playlist
 from .schedule import schedule
+from .channels import channels
 
 
-__all__ = ["watch", "playlist", "schedule"]
+__all__ = ["watch", "playlist", "schedule", "channels"]

--- a/dlhd_proxy/pages/channels.py
+++ b/dlhd_proxy/pages/channels.py
@@ -1,0 +1,102 @@
+import reflex as rx
+from typing import List, TypedDict
+from dlhd_proxy import backend
+from dlhd_proxy.components import navbar
+
+
+class ChannelItem(TypedDict):
+    id: str
+    name: str
+    enabled: bool
+
+
+class ChannelState(rx.State):
+    channels: List[ChannelItem] = []
+
+    async def on_load(self):
+        selected = backend.get_selected_channel_ids()
+        self.channels = [
+            ChannelItem(id=ch.id, name=ch.name, enabled=(ch.id in selected))
+            for ch in backend.get_channels()
+        ]
+
+    def set_channel(self, channel_id: str, value: bool):
+        for ch in self.channels:
+            if ch["id"] == channel_id:
+                ch["enabled"] = value
+                break
+
+    def select_all(self):
+        for ch in self.channels:
+            ch["enabled"] = True
+
+    def select_none(self):
+        for ch in self.channels:
+            ch["enabled"] = False
+
+    async def save(self):
+        ids = [ch["id"] for ch in self.channels if ch["enabled"]]
+        backend.set_selected_channel_ids(ids)
+        try:
+            await backend.generate_guide()
+        except Exception:
+            pass
+        return rx.toast("Channel selection saved")
+
+
+@rx.page("/channels", on_load=ChannelState.on_load)
+def channels() -> rx.Component:
+    return rx.box(
+        navbar(),
+        rx.container(
+            rx.center(
+                rx.card(
+                    rx.vstack(
+                        rx.hstack(
+                            rx.button(
+                                "Select All",
+                                on_click=ChannelState.select_all,
+                            ),
+                            rx.button(
+                                "Select None",
+                                on_click=ChannelState.select_none,
+                                color_scheme="gray",
+                            ),
+                            rx.spacer(),
+                            rx.button(
+                                "Save",
+                                on_click=ChannelState.save,
+                                color_scheme="green",
+                            ),
+                            width="100%",
+                        ),
+                        rx.divider(margin_y="1rem"),
+                        rx.scroll_area(
+                            rx.vstack(
+                                rx.foreach(
+                                    ChannelState.channels,
+                                    lambda ch: rx.checkbox(
+                                        ch["name"],
+                                        checked=ch["enabled"],
+                                        on_change=lambda v, cid=ch["id"]: ChannelState.set_channel(cid, v),
+                                        width="100%",
+                                    ),
+                                ),
+                                spacing="2",
+                                width="100%",
+                            ),
+                            height="60vh",
+                            width="100%",
+                        ),
+                    ),
+                    padding="2rem",
+                    width="100%",
+                    max_width="800px",
+                    border_radius="xl",
+                    box_shadow="lg",
+                ),
+                padding_y="3rem",
+            ),
+            padding_top="7rem",
+        ),
+    )

--- a/dlhd_proxy/step_daddy.py
+++ b/dlhd_proxy/step_daddy.py
@@ -132,9 +132,9 @@ class StepDaddy:
     def content_url(path: str):
         return decrypt(path)
 
-    def playlist(self):
+    def playlist(self, channels: List[Channel] | None = None):
         data = "#EXTM3U\n"
-        for channel in self.channels:
+        for channel in channels or self.channels:
             entry = f" tvg-logo=\"{channel.logo}\",{channel.name}" if channel.logo else f",{channel.name}"
             data += f"#EXTINF:-1{entry}\n{config.api_url}/stream/{channel.id}.m3u8\n"
         return data


### PR DESCRIPTION
## Summary
- allow users to persistently select which channels are enabled
- add channels page with checkboxes and bulk select controls
- filter playlist, schedule, and guide to chosen channels

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b40097f554832f8e581ffe6cb958cf