### PR TITLE
feat: add country filters to channel selection

### DIFF
--- a/dlhd_proxy/pages/channels.py
+++ b/dlhd_proxy/pages/channels.py
@@ -1,38 +1,82 @@
 import reflex as rx
-from typing import List, TypedDict
+from typing import List, Optional, TypedDict
 from dlhd_proxy import backend
 from dlhd_proxy.components import navbar
+import re
 
 
 class ChannelItem(TypedDict):
     id: str
     name: str
     enabled: bool
+    country: Optional[str]
+
+
+COUNTRY_SUFFIXES = ["US", "UK", "Israel", "Spain"]
+
+
+def get_country(name: str) -> Optional[str]:
+    parts = name.split()
+    if not parts:
+        return None
+    last = parts[-1]
+    if last in COUNTRY_SUFFIXES:
+        return last
+    if len(parts) >= 2 and parts[-2] in COUNTRY_SUFFIXES and re.fullmatch(r"HD|FHD|4K", last):
+        return parts[-2]
+    return None
 
 
 class ChannelState(rx.State):
     channels: List[ChannelItem] = []
+    countries: List[str] = []
+    country_states: dict[str, bool] = {}
 
     async def on_load(self):
         selected = backend.get_selected_channel_ids()
-        self.channels = [
-            ChannelItem(id=ch.id, name=ch.name, enabled=(ch.id in selected))
-            for ch in backend.get_channels()
-        ]
+        self.channels = []
+        found_countries = set()
+        for ch in backend.get_channels():
+            country = get_country(ch.name)
+            self.channels.append(
+                ChannelItem(id=ch.id, name=ch.name, enabled=(ch.id in selected), country=country)
+            )
+            if country:
+                found_countries.add(country)
+        self.countries = sorted(found_countries)
+        self.country_states = {
+            c: all(ch["enabled"] for ch in self.channels if ch["country"] == c)
+            for c in self.countries
+        }
 
     def set_channel(self, channel_id: str, value: bool):
         for ch in self.channels:
             if ch["id"] == channel_id:
                 ch["enabled"] = value
+                if ch.get("country"):
+                    country = ch["country"]
+                    self.country_states[country] = all(
+                        c["enabled"] for c in self.channels if c["country"] == country
+                    )
                 break
 
     def select_all(self):
         for ch in self.channels:
             ch["enabled"] = True
+        for c in self.country_states:
+            self.country_states[c] = True
 
     def select_none(self):
         for ch in self.channels:
             ch["enabled"] = False
+        for c in self.country_states:
+            self.country_states[c] = False
+
+    def set_country(self, country: str, value: bool):
+        self.country_states[country] = value
+        for ch in self.channels:
+            if ch["country"] == country:
+                ch["enabled"] = value
 
     async def save(self):
         ids = [ch["id"] for ch in self.channels if ch["enabled"]]
@@ -68,6 +112,20 @@ def channels() -> rx.Component:
                                 on_click=ChannelState.save,
                                 color_scheme="green",
                             ),
+                            width="100%",
+                        ),
+                        rx.divider(margin_y="1rem"),
+                        rx.hstack(
+                            rx.foreach(
+                                ChannelState.countries,
+                                lambda c: rx.checkbox(
+                                    c,
+                                    checked=ChannelState.country_states[c],
+                                    on_change=lambda v, country=c: ChannelState.set_country(country, v),
+                                ),
+                            ),
+                            spacing="2",
+                            wrap="wrap",
                             width="100%",
                         ),
                         rx.divider(margin_y="1rem"),


### PR DESCRIPTION
## Summary
- allow selecting channels by country codes like US/UK/Israel/Spain
- track country selections in state to bulk toggle channels
- display country filter checkboxes above the channel list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4131b81b0832f9b0a78c9ede0cc3d