### PR TITLE
Enumerate duplicate channels for unlisted streams

### DIFF
--- a/dlhd_proxy/backend.py
+++ b/dlhd_proxy/backend.py
@@ -358,6 +358,7 @@ async def generate_guide():
 
     root = Element("tv", attrib={"generator-info-name": "dlhd-proxy"})
     added_channels = set()
+    display_names = {ch.id: ch.name for ch in step_daddy.channels}
 
     # Known channels with logos
     for ch in step_daddy.channels:
@@ -373,7 +374,8 @@ async def generate_guide():
         cid = channel.get("channel_id")
         if cid and cid in selected and cid not in added_channels:
             elem = SubElement(root, "channel", id=cid)
-            SubElement(elem, "display-name").text = channel.get("channel_name", cid)
+            display_name = display_names.get(cid) or channel.get("channel_name", cid)
+            SubElement(elem, "display-name").text = display_name
             added_channels.add(cid)
 
     def iter_channels(data):

--- a/dlhd_proxy/step_daddy.py
+++ b/dlhd_proxy/step_daddy.py
@@ -124,9 +124,28 @@ class StepDaddy:
                             if cid not in channels:
                                 channels[cid] = self._channel_from_schedule(cid, name)
 
-        self.channels = sorted(
-            channels.values(), key=lambda channel: (channel.name.startswith("18"), channel.name)
+        sorted_channels = sorted(
+            channels.values(),
+            key=lambda channel: (channel.name.startswith("18"), channel.name, channel.id),
         )
+        self._enumerate_duplicate_names(sorted_channels)
+        self.channels = sorted_channels
+
+    @staticmethod
+    def _enumerate_duplicate_names(channels: List[Channel]) -> None:
+        """Append numeric suffixes to channels that share a name."""
+
+        counts: Dict[str, int] = {}
+        for channel in channels:
+            counts[channel.name] = counts.get(channel.name, 0) + 1
+
+        seen: Dict[str, int] = {}
+        for channel in channels:
+            name = channel.name
+            if counts.get(name, 0) > 1:
+                index = seen.get(name, 0) + 1
+                seen[name] = index
+                channel.name = f"{name} ({index})"
 
     def _get_channel(self, channel_data: Iterable[str]) -> Channel:
         """Return a channel parsed from the site navigation."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,46 @@
+import asyncio
+from pathlib import Path
+
+from xml.etree import ElementTree
+
+from dlhd_proxy import backend
+from dlhd_proxy.step_daddy import Channel
+
+
+def test_generate_guide_uses_enumerated_names(tmp_path, monkeypatch):
+    guide_path = tmp_path / "guide.xml"
+    monkeypatch.setattr(backend, "GUIDE_FILE", guide_path)
+
+    channels = [
+        Channel(id="1", name="MLB League Pass (1)", tags=[], logo=""),
+        Channel(id="2", name="MLB League Pass (2)", tags=[], logo=""),
+    ]
+    monkeypatch.setattr(backend.step_daddy, "channels", channels, raising=False)
+
+    async def fake_get_schedule():
+        return {
+            "01-01-2024 - Monday": {
+                "Sports": [
+                    {
+                        "time": "12:00",
+                        "event": "Game",
+                        "channels": [
+                            {"channel_id": "1", "channel_name": "MLB League Pass"},
+                            {"channel_id": "2", "channel_name": "MLB League Pass"},
+                        ],
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(backend, "get_schedule", fake_get_schedule)
+    monkeypatch.setattr(backend, "get_selected_channel_ids", lambda: {"1", "2"})
+
+    asyncio.run(backend.generate_guide())
+
+    tree = ElementTree.parse(Path(guide_path))
+    channel_names = [
+        channel.findtext("display-name") for channel in tree.findall("channel")
+    ]
+
+    assert channel_names == ["MLB League Pass (1)", "MLB League Pass (2)"]

--- a/tests/test_step_daddy.py
+++ b/tests/test_step_daddy.py
@@ -1,0 +1,19 @@
+from dlhd_proxy.step_daddy import Channel, StepDaddy
+
+
+def test_enumerate_duplicate_names():
+    channels = [
+        Channel(id="1", name="MLB League Pass", tags=[], logo="logo1"),
+        Channel(id="2", name="MLB League Pass", tags=[], logo="logo2"),
+        Channel(id="3", name="Other", tags=[], logo="logo3"),
+        Channel(id="4", name="MLB League Pass", tags=[], logo="logo4"),
+    ]
+
+    StepDaddy._enumerate_duplicate_names(channels)
+
+    assert [channel.name for channel in channels] == [
+        "MLB League Pass (1)",
+        "MLB League Pass (2)",
+        "Other",
+        "MLB League Pass (3)",
+    ]


### PR DESCRIPTION
## Summary
- enumerate duplicate channel names when loading data from the upstream service so unlisted streams like MLB League Pass appear separately
- ensure the XMLTV guide uses the same enumerated display names for each channel entry
- add tests covering the duplicate enumeration helper and guide generation behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d77665a2d0832fadcca18879518cac