### PR TITLE
Improve channel layout and persist channel selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This is a fork of a self-hosted IPTV proxy built with [Reflex](https://reflex.de
    docker compose up -d
    ```
 
+   The compose file mounts a local `data/` directory into the container so that
+   channel selections saved through the UI persist across rebuilds.
+
 To run with plain Docker:
 
 ```bash
@@ -48,6 +51,12 @@ docker run -p 3000:3000 dlhd-proxy
 - **GUIDE_UPDATE**: Daily time (`HH:MM`) to refresh `guide.xml`.
 
 Edit the `.env` for docker compose.
+
+### Channel Selection Persistence
+
+Custom channel selections are stored in `data/selected_channels.json`. This
+directory is mounted as a Docker volume, so the preferences persist when the
+container is rebuilt or updated.
 
 ### Example Docker Command
 ```bash

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/dlhd_proxy/dlhd_proxy.py
+++ b/dlhd_proxy/dlhd_proxy.py
@@ -31,16 +31,24 @@ class State(rx.State):
 
 @rx.page("/")
 def index() -> rx.Component:
-    channel_grid = rx.grid(
+    channel_grid = rx.flex(
         rx.foreach(
             State.filtered_channels,
-            lambda channel: card(channel),
+            lambda channel: rx.box(
+                card(channel),
+                width="100%",
+                max_width="320px",
+                min_width="240px",
+                style={"flex": "1 1 260px"},
+            ),
         ),
-        grid_template_columns="repeat(auto-fill, minmax(250px, 1fr))",
+        wrap="wrap",
+        justify="center",
+        align="stretch",
         spacing=rx.breakpoints(
             initial="4",
             sm="6",
-            lg="9"
+            lg="7",
         ),
         width="100%",
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,5 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
## Summary
- replace the homepage channel list with a responsive flex layout that wraps cards across the available width
- persist saved channel selections to a shared data directory and mount it in docker-compose for rebuilds
- document the new persistence behavior and add a placeholder for the data directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7798df9e0832f908fc71f96ffd22f